### PR TITLE
Support more attributes: 'vault.policies', 'meta.whatever' and 'variables.whatever'

### DIFF
--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -21,7 +21,17 @@ func CollectDiagnisticsDFS(body hcl.Body, diags *hcl.Diagnostics, schemaMap map[
 		return make(hcl.Diagnostics, 0)
 	}
 
-	bodyContent, allDiags := body.Content(currSchema)
+	var bodyContent *hcl.BodyContent
+	var allDiags hcl.Diagnostics
+
+	// Use PartialContent for schemas that allow any attribute (like `variables` or `meta`)
+	// to avoid false errors for user-defined attributes
+	if langSchema != nil && langSchema.AnyAttribute != nil {
+		bodyContent, _, allDiags = body.PartialContent(currSchema)
+	} else {
+		bodyContent, allDiags = body.Content(currSchema)
+	}
+
 	blocksByType := bodyContent.Blocks.ByType()
 
 	for k, v := range blocksByType {

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -8,15 +8,15 @@ import (
 	"github.com/loczek/nomad-ls/internal/schema"
 )
 
-func CollectDiagnistics(body hcl.Body, schemaMap map[string]*hcl.BodySchema) *hcl.Diagnostics {
+func CollectDiagnostics(body hcl.Body, schemaMap map[string]*hcl.BodySchema) *hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
-	diags = diags.Extend(CollectDiagnisticsDFS(body, &diags, schemaMap, schema.SchemaMapBetter["root"], &schema.RootBodySchema))
+	diags = diags.Extend(CollectDiagnosticsDFS(body, &diags, schemaMap, schema.SchemaMapBetter["root"], &schema.RootBodySchema))
 
 	return &diags
 }
 
-func CollectDiagnisticsDFS(body hcl.Body, diags *hcl.Diagnostics, schemaMap map[string]*hcl.BodySchema, currSchema *hcl.BodySchema, langSchema *hclschema.BodySchema) hcl.Diagnostics {
+func CollectDiagnosticsDFS(body hcl.Body, diags *hcl.Diagnostics, schemaMap map[string]*hcl.BodySchema, currSchema *hcl.BodySchema, langSchema *hclschema.BodySchema) hcl.Diagnostics {
 	if currSchema == nil {
 		return make(hcl.Diagnostics, 0)
 	}
@@ -37,14 +37,14 @@ func CollectDiagnisticsDFS(body hcl.Body, diags *hcl.Diagnostics, schemaMap map[
 	for k, v := range blocksByType {
 		for _, b := range v {
 			if langSchema.Blocks[k] != nil && langSchema.Blocks[k].Body != nil {
-				allDiags = allDiags.Extend(CollectDiagnisticsDFS(b.Body, diags, schemaMap, schemaMap[k], langSchema.Blocks[k].Body))
+				allDiags = allDiags.Extend(CollectDiagnosticsDFS(b.Body, diags, schemaMap, schemaMap[k], langSchema.Blocks[k].Body))
 			} else if langSchema.Blocks[k] != nil && langSchema.Blocks[k].DependentBody != nil {
 				if bodyContent.Attributes["driver"] != nil {
 					driver, _ := bodyContent.Attributes["driver"].Expr.Value(&hcl.EvalContext{})
 
 					schemaMapDependentKey := fmt.Sprintf("%s:%s", k, driver.AsString())
 
-					allDiags = allDiags.Extend(CollectDiagnisticsDFS(b.Body, diags, schemaMap, schemaMap[schemaMapDependentKey], langSchema.Blocks[k].DependentBody[hclschema.SchemaKey(driver.AsString())]))
+					allDiags = allDiags.Extend(CollectDiagnosticsDFS(b.Body, diags, schemaMap, schemaMap[schemaMapDependentKey], langSchema.Blocks[k].DependentBody[hclschema.SchemaKey(driver.AsString())]))
 				}
 			}
 		}

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -84,7 +84,7 @@ func (s *Service) HandleTextDocumentCompletion(ctx context.Context, params *prot
 func (s *Service) HandleTextDocumentDidOpen(ctx context.Context, params *protocol.DidOpenTextDocumentParams) (*hcl.Diagnostics, error) {
 	file, diags := s.parser.ParseHCL([]byte(params.TextDocument.Text), params.TextDocument.URI.Filename())
 
-	schemaDiags := CollectDiagnistics(file.Body, s.schemaMap)
+	schemaDiags := CollectDiagnostics(file.Body, s.schemaMap)
 
 	allDiags := diags.Extend(*schemaDiags)
 
@@ -105,7 +105,7 @@ func (s *Service) HandleTextDocumentDidChange(ctx context.Context, params *proto
 
 		body := file.Body
 
-		schemaDiags := CollectDiagnistics(body, s.schemaMap)
+		schemaDiags := CollectDiagnostics(body, s.schemaMap)
 
 		allDiags := diags.Extend(*schemaDiags)
 

--- a/internal/lsp/testdata/generic.nomad.hcl
+++ b/internal/lsp/testdata/generic.nomad.hcl
@@ -7,6 +7,10 @@ job "example" {
   datacenters = ["dc1"]
   type        = "service"
 
+  meta {
+		owner = "dev-team"
+  }
+
   group "app" {
     count = 1
 

--- a/internal/lsp/testdata/invalid_attribute.nomad.hcl
+++ b/internal/lsp/testdata/invalid_attribute.nomad.hcl
@@ -1,0 +1,19 @@
+job "example" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  # This attribute doesn't exist in the job schema
+  invalid_attribute_that_should_error = "test"
+
+  group "app" {
+    count = 1
+
+    task "server" {
+      driver = "exec"
+
+      config {
+        command = "/bin/echo"
+      }
+    }
+  }
+}

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -1,8 +1,27 @@
 package schema
 
 import (
+	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl-lang/schema"
+	"github.com/zclconf/go-cty/cty"
 )
 
-// TODO: this should be a key value pair map
-var MetaSchema = &schema.BodySchema{}
+// MetaSchema defines the schema for a `meta` block.
+// This block allows specifying arbitrary key-value metadata
+// that can be used for job organization, templating, or
+// passing information to tasks.
+//
+// Example:
+//
+//	meta {
+//	  environment = "production"
+//	  team        = "platform"
+//	}
+var MetaSchema = &schema.BodySchema{
+	Description: lang.Markdown("Specifies a key-value map that annotates with user-defined metadata."),
+	AnyAttribute: &schema.AttributeSchema{
+		Description: lang.Markdown("A user-defined key-value pair for metadata."),
+		Constraint:  &schema.LiteralType{Type: cty.String},
+		IsOptional:  true,
+	},
+}

--- a/internal/schema/vault.go
+++ b/internal/schema/vault.go
@@ -53,6 +53,13 @@ var VaultSchema = &schema.BodySchema{
 			Constraint:   &schema.LiteralType{Type: cty.String},
 			IsOptional:   true,
 		},
+		// TODO: mark as deprecated
+		"policies": {
+			Description:  lang.Markdown("Specifies the set of Vault policies that the task requires. The Nomad client will retrieve a Vault token that is limited to those policies. This field may only be used with the legacy Vault authentication workflow and not with JWT and workload identity. It is deprecated in favor of the `role` field and will be removed in Nomad 1.10."),
+			DefaultValue: &schema.DefaultValue{Value: cty.ListValEmpty(cty.String)},
+			Constraint:   &schema.LiteralType{Type: cty.List(cty.String)},
+			IsOptional:   true,
+		},
 		"role": {
 			Description:  lang.Markdown("Specifies the Vault role used when retrieving a token from Vault using JWT and workload identity. If not specified the client's [`create_from_role`](https://developer.hashicorp.com/nomad/docs/configuration/vault#create_from_role) value is used."),
 			DefaultValue: &schema.DefaultValue{Value: cty.StringVal("")},


### PR DESCRIPTION
Support any attribute in `variables` and `meta` blocks.

Support the now deprecated `vault.policies`.