### PR TITLE
Spelling fix for network.dns.server -> .servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ $ make
 
 - [Zed](https://github.com/loczek/zed-nomad-extension) 
 - VSCode (todo)
+
+### Updating the language server while using it for the Zed Nomad Extension
+If you are already using the [Zed Nomad Extension](https://github.com/loczek/zed-nomad-extension) and want your changes in this repo to be reflected, please
+1. Run `go install` in this repo to install the updated binary to your `$GOPATH`.
+2. Open Zed's command palette (`Cmd+Shift+P`) and run `zed: reload extensions`

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ $ make
 ### Updating the language server while using it for the Zed Nomad Extension
 If you are already using the [Zed Nomad Extension](https://github.com/loczek/zed-nomad-extension) and want your changes in this repo to be reflected, please
 1. Run `go install` in this repo to install the updated binary to your `$GOPATH`.
-2. Open Zed's command palette (`Cmd+Shift+P`) and run `zed: reload extensions`
+2. Open Zed's command palette (`Cmd+Shift+P`) and run `workspace: reload`

--- a/internal/schema/network.go
+++ b/internal/schema/network.go
@@ -91,7 +91,7 @@ var PortSchema = &schema.BodySchema{
 
 var DnsSchema = &schema.BodySchema{
 	Attributes: map[string]*schema.AttributeSchema{
-		"server": {
+		"servers": {
 			Description: lang.Markdown("Sets the DNS nameservers the allocation uses for name resolution."),
 			Constraint:  &schema.LiteralType{Type: cty.List(cty.String)},
 		},


### PR DESCRIPTION
1. Attribute name spelling fix `job.network.dns.server` -> `.servers`
    - Source https://developer.hashicorp.com/nomad/docs/job-specification/network#servers
2. A small note on how to get Zed to recognise your nomad-ls changes while developing