### PR TITLE
Make some upstream configuration items optional

### DIFF
--- a/internal/schema/sidecar_service.go
+++ b/internal/schema/sidecar_service.go
@@ -186,22 +186,25 @@ var UpstreamsSchema = &schema.BodySchema{
 		"destination_namespace": {
 			Description: lang.Markdown("Name of the upstream Consul namespace."),
 			Constraint:  &schema.LiteralType{Type: cty.String},
-			IsRequired:  true,
+			IsOptional:  true,
 		},
 		"destination_partition": {
 			Description:  lang.Markdown("Name of the Cluster admin partition containing the upstream service."),
 			DefaultValue: &schema.DefaultValue{Value: cty.StringVal("")},
 			Constraint:   &schema.LiteralType{Type: cty.String},
+			IsOptional:   true,
 		},
 		"destination_peer": {
 			Description:  lang.Markdown("Name of the peer cluster containing the upstream service."),
 			DefaultValue: &schema.DefaultValue{Value: cty.StringVal("")},
 			Constraint:   &schema.LiteralType{Type: cty.String},
+			IsOptional:   true,
 		},
 		"destination_type": {
 			Description:  lang.Markdown("The type of discovery query the proxy should use for finding service mesh instances."),
 			DefaultValue: &schema.DefaultValue{Value: cty.StringVal("service")},
 			Constraint:   &schema.LiteralType{Type: cty.String},
+			IsOptional:   true,
 		},
 		"local_bind_port": {
 			Description: lang.Markdown("The port the proxy will receive connections for the upstream on."),


### PR DESCRIPTION
Corrected the optionality of some `upstream` keywords

**Source**
https://developer.hashicorp.com/consul/docs/reference/proxy/connect-proxy#upstream-configuration-reference