### PR TITLE
Add Docker logging configuration schema and test

### DIFF
--- a/internal/lsp/lsp_test.go
+++ b/internal/lsp/lsp_test.go
@@ -14,6 +14,7 @@ const (
 	LOKI_NOMAD_FILE_PATH              = "./testdata/loki.nomad.hcl"
 	GENERIC_NOMAD_FILE_PATH           = "./testdata/generic.nomad.hcl"
 	INVALID_ATTRIBUTE_NOMAD_FILE_PATH = "./testdata/invalid_attribute.nomad.hcl"
+	DOCKER_LOGGING_NOMAD_FILE_PATH    = "./testdata/docker_logging.nomad.hcl"
 )
 
 func TestByteCount(t *testing.T) {
@@ -96,6 +97,26 @@ func TestBlockCompletion(t *testing.T) {
 
 func TestMetaBlockAllowsAnyAttribute(t *testing.T) {
 	hclFile := LoadSampleFile(GENERIC_NOMAD_FILE_PATH)
+
+	diags := CollectDiagnostics(hclFile.Body)
+
+	// Filter for errors only (ignore warnings)
+	var errors hcl.Diagnostics
+	for _, d := range *diags {
+		if d.Severity == hcl.DiagError {
+			errors = append(errors, d)
+		}
+	}
+
+	if len(errors) > 0 {
+		for _, d := range errors {
+			t.Errorf("unexpected diagnostic: %s at %v", d.Summary, d.Subject)
+		}
+	}
+}
+
+func TestDockerLoggingConfigBlock(t *testing.T) {
+	hclFile := LoadSampleFile(DOCKER_LOGGING_NOMAD_FILE_PATH)
 
 	diags := CollectDiagnostics(hclFile.Body)
 

--- a/internal/lsp/testdata/docker_logging.nomad.hcl
+++ b/internal/lsp/testdata/docker_logging.nomad.hcl
@@ -1,0 +1,30 @@
+job "docker-logging-test" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "app" {
+    count = 1
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image = "nginx:latest"
+
+        logging {
+          type = "fluentd"
+          config {
+            fluentd-address = "localhost:24224"
+            tag             = "docker.nginx"
+            fluentd-async   = "true"
+          }
+        }
+      }
+
+      resources {
+        cpu    = 500
+        memory = 256
+      }
+    }
+  }
+}

--- a/internal/schema/drivers/docker.go
+++ b/internal/schema/drivers/docker.go
@@ -335,11 +335,17 @@ var LoggingSchema = &schema.BodySchema{
 			Constraint:   &schema.LiteralType{Type: cty.String},
 			IsOptional:   true,
 		},
+	},
+	Blocks: map[string]*schema.BlockSchema{
 		"config": {
-			Description:  lang.Markdown("A key-value map of logging driver configuration options. Defaults to `{ max-file = \"2\", max-size = \"2m\" }`. This option can be used to pass further configuration to the logging driver."),
-			DefaultValue: &schema.DefaultValue{Value: cty.MapVal(map[string]cty.Value{"max-file": cty.StringVal("2"), "max-size": cty.StringVal("2m")})},
-			Constraint:   &schema.LiteralType{Type: cty.Map(cty.String)},
-			IsOptional:   true,
+			Description: lang.Markdown("A key-value map of logging driver configuration options. Defaults to `{ max-file = \"2\", max-size = \"2m\" }`. This option can be used to pass further configuration to the logging driver."),
+			Body: &schema.BodySchema{
+				AnyAttribute: &schema.AttributeSchema{
+					Description: lang.Markdown("Logging driver configuration option."),
+					Constraint:  &schema.LiteralType{Type: cty.String},
+					IsOptional:  true,
+				},
+			},
 		},
 	},
 }


### PR DESCRIPTION
Fix the broken schema of docker `config/logging/config` to allow the key-value map of logging driver configuration options.