### PR TITLE
fix: unexpected block `dynamic`

### DIFF
--- a/internal/schema/job/group.go
+++ b/internal/schema/job/group.go
@@ -141,12 +141,14 @@ func attrKey(value string) schema.SchemaKey {
 }
 
 func createConfigSchema(innerBody *schema.BodySchema) *schema.BodySchema {
-	return &schema.BodySchema{
-		Blocks: map[string]*schema.BlockSchema{
-			"config": {
-				Description: lang.PlainText("Specifies the driver configuration, which is passed directly to the driver to start the task. The details of configurations are specific to each driver, so please see specific driver documentation for more information."),
-				Body:        innerBody,
-			},
-		},
+	var innerTask = TaskSchema.Copy()
+
+	var driverConfig = &schema.BlockSchema{
+		Description: lang.PlainText("Specifies the driver configuration, which is passed directly to the driver to start the task. The details of configurations are specific to each driver, so please see specific driver documentation for more information."),
+		Body:        innerBody,
 	}
+
+	innerTask.Blocks["config"] = driverConfig
+
+	return innerTask
 }

--- a/internal/schema/job/job.go
+++ b/internal/schema/job/job.go
@@ -7,6 +7,7 @@ import (
 )
 
 var JobSchema = &schema.BodySchema{
+	Extensions: &schema.BodyExtensions{DynamicBlocks: true},
 	Attributes: map[string]*schema.AttributeSchema{
 		"all_at_once": {
 			Description:  lang.PlainText("Controls whether the scheduler can make partial placements if optimistic scheduling resulted in an oversubscribed node. This does not control whether all allocations for the job, where all would be the desired count for each task group, must be placed atomically. This should only be used for special circumstances."),


### PR DESCRIPTION
Closes: #17

Using dynamic block label as a reference for completion isn't supported upstream: https://github.com/hashicorp/hcl-lang/issues/172