### PR TITLE
action requires a name label

### DIFF
--- a/internal/schema/job/task.go
+++ b/internal/schema/job/task.go
@@ -97,6 +97,11 @@ var TaskSchema = &schema.BodySchema{
 		// TODO: add docs in the future
 		"action": {
 			Description: lang.PlainText("action docs"),
+			Labels: []*schema.LabelSchema{
+				{
+					Name: "name",
+				},
+			},
 			Body:        ActionSchema,
 		},
 		"artifact": {


### PR DESCRIPTION
At the moment the follow generates an error.

```hcl
      action "graceful-restart" {
        command = "/bin/sh"
        args    = ["-c",
          <<EOT
PID_SIDECAR=`pidof traefik-cert-sidecar`
kill -SIGUSR1 $PID_SIDECAR
    EOT
        ]
      }
```

Error:

```log
Too many labels specified for "action"
```